### PR TITLE
[PKG-3728] Initial build 2.10.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload-channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 2242603497bbcdb6e565c883df7b48eb85e19439acab54026a0e2b1cae6b5fe6
 
 build:
-  noarch: python
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
+    - python
     - pip
     - poetry-core >=1.0.0
-    - python >=3.6,<4.0
   run:
-    - python >=3.6,<4.0
+    - python
     - sqlparse >=0.4.1,<0.5.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sql-metadata" %}
-{% set version = "2.6.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sql_metadata-{{ version }}.tar.gz
-  sha256: 2242603497bbcdb6e565c883df7b48eb85e19439acab54026a0e2b1cae6b5fe6
+  sha256: 69f9ef71ac69759ae339f0aab6a8a718cf548100d08b742d24bb1800b7a2ea20
 
 build:
   skip: true  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,14 @@ requirements:
 test:
   imports:
     - sql_metadata
+  source_files:
+    - test
   commands:
     - pip check
+    - pytest -v test
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/macbre/sql-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sql_metadata-{{ version }}.tar.gz
-  sha256: 69f9ef71ac69759ae339f0aab6a8a718cf548100d08b742d24bb1800b7a2ea20
+  url: https://github.com/macbre/sql-metadata/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 7577a26fb095a4ee71090d254ee83c1e6be46174739efccbc8ccdd3f7559045b
 
 build:
   skip: true  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,15 @@ test:
 about:
   home: https://github.com/macbre/sql-metadata
   summary: Uses tokenized query returned by python-sqlparse and generates query metadata
+  description: |
+    Uses tokenized query returned by python-sqlparse and generates query metadata.
+    Extracts column names and tables used by the query. Automatically conduct column alias resolution, 
+    sub queries aliases resolution as well as tables aliases resolving.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  doc_url: https://github.com/macbre/sql-metadata/blob/master/README.md
+  dev_url: https://github.com/macbre/sql-metadata
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
sql-metadata 2.10.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3728](https://anaconda.atlassian.net/browse/PKG-3728) 
- [Upstream repository](https://github.com/macbre/sql-metadata/tree/v2.10.0)
- [Upstream changelog/diff](https://github.com/macbre/sql-metadata/releases/tag/v2.10.0)

### Explanation of changes:

- Swapped to Github sdist as tests were not included in the pypi sdist.


[PKG-3728]: https://anaconda.atlassian.net/browse/PKG-3728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ