### PR TITLE
Rebuild with fixed abs.yaml

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-upload-channels:
+upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Previous PR used `upload-channels` instead of `upload_channels`